### PR TITLE
Kalman based filters require the noise around zero not be truncated

### DIFF
--- a/src/flow.c
+++ b/src/flow.c
@@ -460,7 +460,7 @@ uint8_t compute_flow(uint8_t *image1, uint8_t *image2, float x_rate, float y_rat
 		}
 
 		/* check if there is a peak value in histogram */
-		if (histx[maxpositionx] > meancount / 6 && histy[maxpositiony] > meancount / 6)
+		if (1) //(histx[maxpositionx] > meancount / 6 && histy[maxpositiony] > meancount / 6)
 		{
 			if (global_data.param[PARAM_BOTTOM_FLOW_HIST_FILTER])
 			{


### PR DESCRIPTION
When using the optical flow output of the sensor module as observations of state in any sort of Kalman filter, the discontinuity caused by this condition tends to cause state divergence as the output measurements approach or hover around zero setting up estimated state oscillations.

This change is a quick fix for the problem and has been tested and shown to resolve the issue in my use case.  Although this may not be the ideal solution, it is intended to open discussion so that a final fix can be formulated.

The first question is:

Is there any justification for the raw pixel output to be forced to zero if a seemingly ad hoc histogram peak level is not detected when the user has requested the FLOW_HIST_FILTER be turned off?
