### PR TITLE
Utilize more of the available field of view for flow computation

### DIFF
--- a/src/flow.c
+++ b/src/flow.c
@@ -48,6 +48,11 @@
 #define __ASM asm
 #include "core_cm4_simd.h"
 
+#define FRAME_SIZE	global_data.param[PARAM_IMAGE_WIDTH]
+#define SEARCH_SIZE	(4 + 1)         // maximum offset to search: 4 + 1/2 pixels
+#define TILE_SIZE	8               // x & y tile size
+#define NUM_BLOCKS	8               // x & y number of tiles to check
+
 #define sign(x) (( x > 0 ) - ( x < 0 ))
 
 /**
@@ -325,6 +330,9 @@ uint8_t compute_flow(uint8_t *image1, uint8_t *image2, float x_rate, float y_rat
 	const uint16_t hist_size = 2*(winmax-winmin+1)+1;
 
 	/* variables */
+        uint16_t pixLo = SEARCH_SIZE;
+        uint16_t pixHi = FRAME_SIZE - SEARCH_SIZE - TILE_SIZE;
+        uint16_t pixStep = (pixHi - pixLo) / NUM_BLOCKS + 1;
 	uint16_t i, j;
 	uint32_t acc[8]; // subpixels
 	uint16_t histx[hist_size]; // counter for x shift
@@ -343,9 +351,9 @@ uint8_t compute_flow(uint8_t *image1, uint8_t *image2, float x_rate, float y_rat
 
 	/* iterate over all patterns
 	 */
-	for (j = 8; j <= 57; j += 7)
+	for (j = pixLo; j < pixHi; j += pixStep)
 	{
-		for (i = 8; i <= 57; i += 7)
+		for (i = pixLo; i < pixHi; i += pixStep)
 		{
 			/* test pixel if it is suitable for flow tracking */
 			uint32_t diff = compute_diff(image1, i, j, (uint16_t) global_data.param[PARAM_IMAGE_WIDTH]);
@@ -416,9 +424,9 @@ uint8_t compute_flow(uint8_t *image1, uint8_t *image2, float x_rate, float y_rat
 	if (global_data.param[PARAM_USB_SEND_VIDEO] && global_data.param[PARAM_VIDEO_USB_MODE] == FLOW_VIDEO)
 	{
 
-		for (j = 8; j <= 57; j += 7)
+		for (j = pixLo; j < pixHi; j += pixStep)
 		{
-			for (i = 8; i <= 57; i += 7)
+			for (i = pixLo; i < pixHi; i += pixStep)
 			{
 
 				uint32_t diff = compute_diff(image1, i, j, (uint16_t) global_data.param[PARAM_IMAGE_WIDTH]);


### PR DESCRIPTION
This change spreads the patterns chosen for SAD computation more evenly over the available 64x64 pixel image instead of overlapping and bunching them up in a smaller area.  This should give the system a better chance at finding good flow candidates in more difficult situations.

This code has been tested and found to work properly.
