### PR TITLE
Initialize GPIOs for EXPOSURE and STANDBY lines of the camera

### DIFF
--- a/src/dcmi.c
+++ b/src/dcmi.c
@@ -558,6 +558,15 @@ void dcmi_hw_init(void)
 
 	/* Initialize the I2C peripheral w/ selected parameters */
 	I2C_Init(I2C2, &I2C_InitStruct);
+
+	/* Initialize GPIOs for EXPOSURE and STANDBY lines of the camera */
+	GPIO_InitStructure.GPIO_Pin = GPIO_Pin_2 | GPIO_Pin_3;
+	GPIO_InitStructure.GPIO_Mode = GPIO_Mode_OUT;
+	GPIO_InitStructure.GPIO_OType = GPIO_OType_PP;
+	GPIO_InitStructure.GPIO_Speed = GPIO_Speed_2MHz;
+	GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_NOPULL;
+	GPIO_Init(GPIOA, &GPIO_InitStructure);
+	GPIO_ResetBits(GPIOA, GPIO_Pin_2 | GPIO_Pin_3);
 }
 
 /**


### PR DESCRIPTION
This keeps these data lines from floating and causing dark lines in the image.

Although I realize this doesn't fix the issue that some other users were having, it did solve my issue.

See my initial investigation: https://groups.google.com/d/msg/px4users/-eBFpNyOoXU/XUpZUa_FDc8J
Example images: https://groups.google.com/d/msg/px4users/-eBFpNyOoXU/23Kuna93yaUJ
