### PR TITLE
Removed i2c struct packing due to alignment warning.

### DIFF
--- a/inc/i2c.h
+++ b/inc/i2c.h
@@ -1,7 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (C) 2013 Fortiss An-Institut TU Munchen All rights reserved.
- *   Author: Thomas Boehm <thomas.boehm@fortiss.org>
+ *   Copyright (c) 2013-2015 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -13,6 +12,9 @@
  *    notice, this list of conditions and the following disclaimer in
  *    the documentation and/or other materials provided with the
  *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
@@ -28,6 +30,14 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  ****************************************************************************/
+
+/**
+ * @file i2c.h
+ * I2C communication functions.
+ * @author Thomas Boehm <thomas.boehm@fortiss.org>
+ */
+
+
 #ifndef I2C_H_
 #define I2C_H_
 #include <inttypes.h>

--- a/inc/i2c_frame.h
+++ b/inc/i2c_frame.h
@@ -1,7 +1,6 @@
 /****************************************************************************
  *
- *   Copyright (C) 2013 Fortiss An-Institut TU Munchen All rights reserved.
- *   Author: Thomas Boehm <thomas.boehm@fortiss.org>
+ *   Copyright (c) 2013-2015 PX4 Development Team. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -13,6 +12,9 @@
  *    notice, this list of conditions and the following disclaimer in
  *    the documentation and/or other materials provided with the
  *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
@@ -28,13 +30,18 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  ****************************************************************************/
+
+/**
+ * @file i2c_frame.h
+ * Definition of i2c frames.
+ * @author Thomas Boehm <thomas.boehm@fortiss.org>
+ * @author James Goppert <james.goppert@gmail.com>
+ */
+
 #ifndef I2C_FRAME_H_
 #define I2C_FRAME_H_
 #include <inttypes.h>
 
-// ***Take care***: struct alignment isn't necessarily what you expect,
-// so unaligned (i.e., single uint8_t values) should go at the end.
-// Otherwise nothing will work.
 
 typedef  struct i2c_frame
 {
@@ -50,7 +57,7 @@ typedef  struct i2c_frame
     uint8_t gyro_range;
     uint8_t sonar_timestamp;
     int16_t ground_distance;
-} __attribute__((packed)) i2c_frame;
+} i2c_frame;
 
 #define I2C_FRAME_SIZE (sizeof(i2c_frame))
 
@@ -68,7 +75,7 @@ typedef struct i2c_integral_frame
     uint16_t ground_distance;
     int16_t gyro_temperature;
     uint8_t qual;
-} __attribute__((packed)) i2c_integral_frame;
+} i2c_integral_frame;
 
 #define I2C_INTEGRAL_FRAME_SIZE (sizeof(i2c_integral_frame))
 


### PR DESCRIPTION
Struct packing wasn't doing much, we only were sending
1 extra byte of pad and I expect to use this byte
in the near future.

This pull request is required for compatibility with the i2c-flow-simpl pull request in PX4/Firmware.