### PR TITLE
Adding parameter saving capability (fixing #19)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,6 +165,7 @@ set(PERIPH_SRC
     lib/STM32F4xx_StdPeriph_Driver/src/stm32f4xx_rcc.c
     lib/STM32F4xx_StdPeriph_Driver/src/stm32f4xx_dma.c
     lib/STM32F4xx_StdPeriph_Driver/src/stm32f4xx_dcmi.c
+    lib/STM32F4xx_StdPeriph_Driver/src/stm32f4xx_flash.c
     lib/STM32F4xx_StdPeriph_Driver/src/stm32f4xx_i2c.c
     lib/STM32F4xx_StdPeriph_Driver/src/stm32f4xx_tim.c
     lib/STM32F4xx_StdPeriph_Driver/src/stm32f4xx_spi.c
@@ -185,6 +186,7 @@ set(PX4FLOW_HDRS
     inc/dcmi.h
     inc/debug.h
     inc/flow.h
+    inc/flash.h
     inc/gyro.h
     inc/i2c_frame.h
     inc/i2c.h
@@ -210,6 +212,7 @@ set(PX4FLOW_SRC
     src/dcmi.c
     src/debug.c
     src/flow.c
+    src/flash.c
     src/gyro.c
     src/i2c.c
     src/led.c

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ SRCS = 		src/main.c \
 			src/settings.c \
 			src/communication.c \
 			src/flow.c \
+			src/flash.c \
 			src/dcmi.c \
 			src/mt9v034.c \
 			src/gyro.c \
@@ -41,6 +42,7 @@ SRCS += 	lib/STM32F4xx_StdPeriph_Driver/src/misc.c \
 			lib/STM32F4xx_StdPeriph_Driver/src/stm32f4xx_rcc.c \
 			lib/STM32F4xx_StdPeriph_Driver/src/stm32f4xx_dma.c \
 			lib/STM32F4xx_StdPeriph_Driver/src/stm32f4xx_dcmi.c \
+			lib/STM32F4xx_StdPeriph_Driver/src/stm32f4xx_flash.c \
 			lib/STM32F4xx_StdPeriph_Driver/src/stm32f4xx_i2c.c \
 			lib/STM32F4xx_StdPeriph_Driver/src/stm32f4xx_tim.c \
 			lib/STM32F4xx_StdPeriph_Driver/src/stm32f4xx_spi.c \

--- a/inc/flash.h
+++ b/inc/flash.h
@@ -1,0 +1,64 @@
+#ifndef FLASH_H_GG
+#define FLASH_H_GG
+
+#include <stdint.h>
+
+#define ADDR_FLASH_GLOBAL_PARAMS 0x080E0000
+
+#define FLASH_OK 0
+#define FLASH_ERROR_ERASE 1
+#define FLASH_ERROR_WRITE 2
+
+/* ------------------------------------- *
+ *  Read, Write and Erase functions      *
+ * ------------------------------------- */
+ /**
+  * @brief  Reads an uint32 buffer from the internal flash at a given address
+  * @param  address: Start address of the flash area to read
+  * @param  buffer: Address where to store the read buffer (user is responsible to allocate memory
+  * @param  buffer_size: Size of the buffer to read in bytes
+  * @retval FLASH Status: always returns FLASH_OK
+  */
+ uint8_t flash_read_buffer_uint32(uint32_t address, uint32_t *buffer, uint16_t buffer_size);
+
+ /**
+  * @brief  Reads a float buffer from the internal flash at a given address
+  * @param  address: Start address of the flash area to read
+  * @param  buffer: Address where to store the read buffer (user is responsible to allocate memory
+  * @param  buffer_size: Size of the buffer to read in bytes
+  * @retval FLASH Status: always returns FLASH_OK
+  */
+ uint8_t flash_read_buffer_float(uint32_t address, float *buffer, uint16_t buffer_size);
+
+ /**
+  * @brief  Writes a uint32 buffer to the internal flash at a given address
+  *         (You need to erase before writing!)
+  * @note   This function requires a device voltage between 2.7V and 3.6V.
+  * @param  address: Start address of the flash area to write
+  * @param  buffer: Address of the buffer to write
+  * @param  buffer_size: Size of the buffer to write in bytes
+  * @retval FLASH Status: The returned value can be: FLASH_OK or FLASH_ERROR_WRITE.
+  */ 
+ uint8_t flash_write_buffer_uint32(uint32_t address, uint32_t *buffer, uint16_t buffer_size);
+ 
+  /**
+  * @brief  Writes a float buffer to the internal flash at a given address
+  *         (You need to erase before writing!)
+  * @note   This function requires a device voltage between 2.7V and 3.6V.
+  * @param  address: Start address of the flash area to write
+  * @param  buffer: Address of the buffer to write
+  * @param  buffer_size: Size of the buffer to write in bytes
+  * @retval FLASH Status: The returned value can be: FLASH_OK or FLASH_ERROR_WRITE.
+  */ 
+ uint8_t flash_write_buffer_float(uint32_t address, float *buffer, uint16_t buffer_size);
+
+
+  /**
+  * @brief  Erases one sector of the internal flash
+  * @note   This function requires a device voltage between 2.7V and 3.6V.
+  * @param  address: an address in the sector to erase
+  * @retval FLASH Status: The returned value can be: FLASH_OK or FLASH_ERROR_ERASE.
+  */ 
+uint8_t flash_erase_sector(uint32_t address);
+
+#endif /* FLASH_H_ */

--- a/inc/flash.h
+++ b/inc/flash.h
@@ -34,9 +34,11 @@
   * @brief  Writes a uint32 buffer to the internal flash at a given address
   *         (You need to erase before writing!)
   * @note   This function requires a device voltage between 2.7V and 3.6V.
+  * @note   The values are read back and compared, if problems are detected,
+  *         we retry MAX_WRITE_TRIALS times and then abort
   * @param  address: Start address of the flash area to write
   * @param  buffer: Address of the buffer to write
-  * @param  buffer_size: Size of the buffer to write in bytes
+  * @param  buffer_size: Number of elements to write (not number of bytes)
   * @retval FLASH Status: The returned value can be: FLASH_OK or FLASH_ERROR_WRITE.
   */ 
  uint8_t flash_write_buffer_uint32(uint32_t address, uint32_t *buffer, uint16_t buffer_size);
@@ -47,18 +49,18 @@
   * @note   This function requires a device voltage between 2.7V and 3.6V.
   * @param  address: Start address of the flash area to write
   * @param  buffer: Address of the buffer to write
-  * @param  buffer_size: Size of the buffer to write in bytes
+  * @param  buffer_size: Number of elements to write (not number of bytes)
   * @retval FLASH Status: The returned value can be: FLASH_OK or FLASH_ERROR_WRITE.
   */ 
  uint8_t flash_write_buffer_float(uint32_t address, float *buffer, uint16_t buffer_size);
 
 
   /**
-  * @brief  Erases one sector of the internal flash
+  * @brief  Erases the sector of the internal flash which contains the given address
   * @note   This function requires a device voltage between 2.7V and 3.6V.
   * @param  address: an address in the sector to erase
   * @retval FLASH Status: The returned value can be: FLASH_OK or FLASH_ERROR_ERASE.
   */ 
-uint8_t flash_erase_sector(uint32_t address);
+uint8_t flash_erase_sector_address(uint32_t address);
 
 #endif /* FLASH_H_ */

--- a/inc/settings.h
+++ b/inc/settings.h
@@ -157,6 +157,13 @@ struct global_struct
 
 };
 
+#define PARAM_OK 0
+#define PARAM_CHANGED 0
+#define PARAM_UNCHANGED 1
+#define PARAM_ERROR 2
+#define PARAM_INVALID_ID 3
+#define PARAM_INVALID_VALUE 4
+
 /* global declarations */
 extern enum global_param_id_t global_param_id;
 extern struct global_struct global_data;
@@ -168,5 +175,37 @@ extern struct global_struct global_data;
 void global_data_reset_param_defaults(void);
 void global_data_reset(void);
 void set_sensor_position_settings(uint8_t sensor_position);
+
+  /**
+  * @brief  Reads values of global_data.param from the internal flash,
+  *         if read is unsuccessful, hard coded default values are used
+  * @retval status: PARAM_OK (=0): reading from flash was successful
+  *                 PARAM_ERROR (=2): reading from flash was successful, loaded hard coded values
+  */
+uint8_t global_data_load_params();
+
+
+  /**
+  * @brief  Writes values of global_data.param to the internal FLASH
+  *         (may erases Sector 11 without restoring it!)
+  * @note   Only writes parameters if they differ from values already stored in FLASH
+  * @note   This function requires a device voltage between 2.7V and 3.6V.
+  * @retval status:   PARAM_CHANGED (=0): parameters were succesfully written to internal FLASH
+  *                   PARAM_UNCHANGED (=1): no changes in parameters: parameters were not written
+  *                   PARAM_ERROR (=2): parameters could not be written to FLASH
+  */
+uint8_t global_data_save_params();
+
+/**
+  * @brief  Set the global parameter and send it through mavlink (does not save it to the internal flash);
+  * @note   To save the parameters to the internal flash, use global_data_save_params()
+  * @param  param_id: Id of the parameter to change
+  * @param  param_value: new value of the parameter
+  * @retval status: PARAM_CHANGED (=0): parameter changed succesfully
+  *                 PARAM_UNCHANGED (=1): parameter stayed the same
+  *                 PARAM_INVALID_ID (=3): parameter id is invalid
+  *                 PARAM_INVALID_ID (=4): parameter value is invalid value
+  */
+uint8_t set_global_data_param(int param_id, float param_value);
 
 #endif /* SETTINGS_H_ */

--- a/src/dcmi.c
+++ b/src/dcmi.c
@@ -83,7 +83,10 @@ void enable_image_capture(void)
 {
 	dcmi_clock_init();
 	dcmi_hw_init();
-	dcmi_dma_init(global_data.param[PARAM_IMAGE_WIDTH] * global_data.param[PARAM_IMAGE_HEIGHT]);
+    if(global_data.param[PARAM_VIDEO_ONLY])
+		dcmi_dma_init(FULL_IMAGE_SIZE);
+	else
+		dcmi_dma_init(global_data.param[PARAM_IMAGE_WIDTH] * global_data.param[PARAM_IMAGE_HEIGHT]);
 	mt9v034_context_configuration();
 	dcmi_dma_enable();
 }

--- a/src/flash.c
+++ b/src/flash.c
@@ -1,0 +1,216 @@
+
+/* Includes ------------------------------------------------------------------*/
+#include "flash.h"
+#include "settings.h"
+#include "stm32f4xx_flash.h"
+
+#define MAX_WRITE_TRIALS  100  /* Number of trials to write to flash */
+
+
+
+/* Base address of the Flash sectors */
+#define ADDR_FLASH_SECTOR_0     ((uint32_t)0x08000000) /* Base @ of Sector 0, 16 Kbytes   bootloader        */
+#define ADDR_FLASH_SECTOR_1     ((uint32_t)0x08004000) /* Base @ of Sector 1, 16 Kbytes   application       */
+#define ADDR_FLASH_SECTOR_2     ((uint32_t)0x08008000) /* Base @ of Sector 2, 16 Kbytes   application       */
+#define ADDR_FLASH_SECTOR_3     ((uint32_t)0x0800C000) /* Base @ of Sector 3, 16 Kbytes   application       */
+#define ADDR_FLASH_SECTOR_4     ((uint32_t)0x08010000) /* Base @ of Sector 4, 64 Kbytes   application       */    
+#define ADDR_FLASH_SECTOR_5     ((uint32_t)0x08020000) /* Base @ of Sector 5, 128 Kbytes                    */
+#define ADDR_FLASH_SECTOR_6     ((uint32_t)0x08040000) /* Base @ of Sector 6, 128 Kbytes                    */
+#define ADDR_FLASH_SECTOR_7     ((uint32_t)0x08060000) /* Base @ of Sector 7, 128 Kbytes                    */
+#define ADDR_FLASH_SECTOR_8     ((uint32_t)0x08080000) /* Base @ of Sector 8, 128 Kbytes                    */
+#define ADDR_FLASH_SECTOR_9     ((uint32_t)0x080A0000) /* Base @ of Sector 9, 128 Kbytes                    */
+#define ADDR_FLASH_SECTOR_10    ((uint32_t)0x080C0000) /* Base @ of Sector 10, 128 Kbytes                   */
+#define ADDR_FLASH_SECTOR_11    ((uint32_t)0x080E0000) /* Base @ of Sector 11, 128 Kbytes global parameters */
+
+
+/* private functions */
+uint32_t GetSector(uint32_t Address);
+
+ /**
+  * @brief  Reads an uint32 buffer from the internal flash at a given address
+  * @param  address: Start address of the flash area to read
+  * @param  buffer: Address where to store the read buffer (user is responsible to allocate memory
+  * @param  buffer_size: Size of the buffer to read in bytes
+  * @retval FLASH Status: always returns FLASH_OK
+  */
+uint8_t flash_read_buffer_uint32(uint32_t address, uint32_t *buffer, uint16_t buffer_size)
+{    
+    for(uint16_t i = 0; i < buffer_size; i++)
+    {
+        buffer[i] = *(__IO uint32_t*)(address+i*4);
+    }
+    return FLASH_OK;
+}
+
+
+ /**
+  * @brief  Reads a float buffer from the internal flash at a given address
+  * @param  address: Start address of the flash area to read
+  * @param  buffer: Address where to store the read buffer (user is responsible to allocate memory
+  * @param  buffer_size: Size of the buffer to read in bytes
+  * @retval FLASH Status: always returns FLASH_OK
+  */
+uint8_t flash_read_buffer_float(uint32_t address, float *buffer, uint16_t buffer_size)
+{
+    return flash_read_buffer_uint32(address, (uint32_t*) buffer, buffer_size);
+}
+
+
+ /**
+  * @brief  Writes a uint32 buffer to the internal flash at a given address
+  *         (You need to erase before writing!)
+  * @note   This function requires a device voltage between 2.7V and 3.6V.
+  * @note   The values are read back and compared, if problems are detected,
+  *         we retry MAX_WRITE_TRIALS times and then abort
+  * @param  address: Start address of the flash area to write
+  * @param  buffer: Address of the buffer to write
+  * @param  buffer_size: Size of the buffer to write in bytes
+  * @retval FLASH Status: The returned value can be: FLASH_BUSY, FLASH_ERROR_PROGRAM,
+  *                       FLASH_ERROR_WRP, FLASH_ERROR_OPERATION or FLASH_COMPLETE.
+  */ 
+uint8_t flash_write_buffer_uint32(uint32_t address, uint32_t *buffer, uint16_t buffer_size)
+{
+    FLASH_Unlock();
+    
+    /* we write everything and than check what we wrote */
+    uint32_t i = 0;
+    uint32_t trials = 0;
+    uint8_t write_error;
+    FLASH_Status status = FLASH_COMPLETE;
+    do{
+        write_error = 0;
+        trials ++;
+        /* Write parameters to flash (WE ASSUME VOLTAGE OF 2.7V to 3.6V) */
+        for(; i < buffer_size; i++)
+        {
+            status = FLASH_ProgramWord(address+i*4, buffer[i]);
+            if(status != FLASH_COMPLETE)
+            {
+                write_error = 1;
+                break;
+            }
+        }
+        
+        /* if we tried to often, we return FLASH_ERROR_OPERATION */
+        if(trials > MAX_WRITE_TRIALS)
+        {
+            return status;
+        }
+        
+        /* if we had a write error, try again for same index */
+        if(write_error)
+        {
+            continue;
+        }
+        
+        /* Read flash and compare */
+        for(i = 0; i < buffer_size; i++)
+        {
+            if(*(__IO float*)(address+i*4) != buffer[i])
+            {
+                write_error = 1;
+                break;
+            }
+        }
+    }while(write_error);
+    
+    /* we lock the flash to prevent accidental writing */
+    FLASH_Lock();
+    
+    return FLASH_COMPLETE;
+}
+
+
+  /**
+  * @brief  Writes a float buffer to the internal flash at a given address
+  *         (You need to erase before writing!)
+  * @note   This function requires a device voltage between 2.7V and 3.6V.
+  * @param  address: Start address of the flash area to write
+  * @param  buffer: Address of the buffer to write
+  * @param  buffer_size: Size of the buffer to write in bytes
+  * @retval FLASH Status: The returned value can be: FLASH_BUSY, FLASH_ERROR_PROGRAM,
+  *                       FLASH_ERROR_WRP, FLASH_ERROR_OPERATION or FLASH_COMPLETE.
+  */ 
+uint8_t flash_write_buffer_float(uint32_t address, float *buffer, uint16_t buffer_size)
+{
+    return flash_write_buffer_uint32(address, (uint32_t*) buffer, buffer_size);
+}
+
+
+
+  /**
+  * @brief  Erases one sector of the internal flash
+  * @note   This function requires a device voltage between 2.7V and 3.6V.
+  * @note   This function locks the flash after erasing
+  * @param  address: an address in the sector to erase
+  * @retval FLASH Status: The returned value can be: FLASH_BUSY, FLASH_ERROR_PROGRAM,
+  *                       FLASH_ERROR_WRP, FLASH_ERROR_OPERATION or FLASH_COMPLETE.
+  */ 
+uint8_t flash_erase_sector(uint32_t address)
+{
+    FLASH_Unlock();
+    return FLASH_EraseSector(GetSector(address), VoltageRange_3);
+    FLASH_Lock();
+}
+
+
+/**
+  * @brief  Gets the sector of a given address
+  * @param  None
+  * @retval The sector of a given address
+  */
+uint32_t GetSector(uint32_t Address)
+{
+  uint32_t sector = 0;
+  
+  if((Address < ADDR_FLASH_SECTOR_1) && (Address >= ADDR_FLASH_SECTOR_0))
+  {
+    sector = FLASH_Sector_0;  
+  }
+  else if((Address < ADDR_FLASH_SECTOR_2) && (Address >= ADDR_FLASH_SECTOR_1))
+  {
+    sector = FLASH_Sector_1;  
+  }
+  else if((Address < ADDR_FLASH_SECTOR_3) && (Address >= ADDR_FLASH_SECTOR_2))
+  {
+    sector = FLASH_Sector_2;  
+  }
+  else if((Address < ADDR_FLASH_SECTOR_4) && (Address >= ADDR_FLASH_SECTOR_3))
+  {
+    sector = FLASH_Sector_3;  
+  }
+  else if((Address < ADDR_FLASH_SECTOR_5) && (Address >= ADDR_FLASH_SECTOR_4))
+  {
+    sector = FLASH_Sector_4;  
+  }
+  else if((Address < ADDR_FLASH_SECTOR_6) && (Address >= ADDR_FLASH_SECTOR_5))
+  {
+    sector = FLASH_Sector_5;  
+  }
+  else if((Address < ADDR_FLASH_SECTOR_7) && (Address >= ADDR_FLASH_SECTOR_6))
+  {
+    sector = FLASH_Sector_6;  
+  }
+  else if((Address < ADDR_FLASH_SECTOR_8) && (Address >= ADDR_FLASH_SECTOR_7))
+  {
+    sector = FLASH_Sector_7;  
+  }
+  else if((Address < ADDR_FLASH_SECTOR_9) && (Address >= ADDR_FLASH_SECTOR_8))
+  {
+    sector = FLASH_Sector_8;  
+  }
+  else if((Address < ADDR_FLASH_SECTOR_10) && (Address >= ADDR_FLASH_SECTOR_9))
+  {
+    sector = FLASH_Sector_9;  
+  }
+  else if((Address < ADDR_FLASH_SECTOR_11) && (Address >= ADDR_FLASH_SECTOR_10))
+  {
+    sector = FLASH_Sector_10;  
+  }
+  else/*(Address < FLASH_END_ADDR) && (Address >= ADDR_FLASH_SECTOR_11))*/
+  {
+    sector = FLASH_Sector_11;  
+  }
+
+  return sector;
+}

--- a/src/main.c
+++ b/src/main.c
@@ -229,7 +229,7 @@ void buffer_reset(void) {
 int main(void)
 {
 	/* load settings and parameters */
-	global_data_reset_param_defaults();
+	global_data_load_params();
 	global_data_reset();
 
 	/* init led */

--- a/src/settings.c
+++ b/src/settings.c
@@ -272,7 +272,7 @@ uint8_t global_data_save_params(){
     }
     /* (we could check if erasing is really necessary, but it won't safe much) */
     uint8_t flash_status;
-    flash_status = flash_erase_sector(ADDR_FLASH_GLOBAL_PARAMS);
+    flash_status = flash_erase_sector_address(ADDR_FLASH_GLOBAL_PARAMS);
     flash_status = flash_write_buffer_float(ADDR_FLASH_GLOBAL_PARAMS, global_data.param, ONBOARD_PARAM_COUNT);
 
     /* get checksum and write it also to internal flash */


### PR DESCRIPTION
Parameters are now saved automatically to flash when sent to PX4Flow.
If no parameters are saved, it falls back to default parameters (as defined in settings.c)
I moved the setting of the parameters from 'communication.c:handle_mavlink_message' to 'settings.c:set_global_data_param', since it concerns the settings and not the communcication.
This allows to set parameters easily during runtime.
Parameters are only saved if sent via mavlink, not if they are setted using 'set_global_data_param(..)'.
We could also changed this...
Added basic functions to write to flash memory ('flash.c')