### PR TITLE
Makefile & linker script fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,13 +55,12 @@ SRCS += 	lib/STM32F4xx_StdPeriph_Driver/src/misc.c \
 			lib/STM32_USB_Device_Library/Core/src/usbd_ioreq.c \
 			lib/STM32_USB_Device_Library/Class/cdc/src/usbd_cdc_core.c
 
-.PHONY: clean upload-usb
-
 CFLAGS		 = -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 \
 			-O3 \
+			-ggdb \
 			-std=gnu99 \
-			-Wall \
-			-MD \
+			-Wall -Werror \
+			-MMD \
 			-Iinc \
 			-Ilib \
 			-Ilib/STM32F4xx_StdPeriph_Driver/inc \
@@ -78,16 +77,20 @@ LDFLAGS		 = -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 \
 			-Tstm32f4.ld \
 			-Wl,-gc-sections \
 			-lm
+			
+-include $(BINARY:.elf=.d)
 
-all:		$(BINARY) objcopy
+all: px4flow.px4
 
 $(BINARY):	$(SRCS)
-	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
-	
-objcopy:
+	$(CC) $(CFLAGS) $(SRCS) -o $@ $(LDFLAGS)
+
+px4flow.px4: px4flow.elf
 	@$(OBJCOPY) -O binary px4flow.elf px4flow.bin
 	@python -u Tools/px_mkfw.py --board_id 6 > px4flow_prototype.px4
 	@python -u Tools/px_mkfw.py --prototype px4flow_prototype.px4 --image $(BINARY_BIN) > px4flow.px4
+	
+objcopy: px4flow.px4
 
 clean:
 	rm -f *.o *.d $(BINARY) $(BINARY_BIN)
@@ -119,11 +122,9 @@ ifeq ($(SERIAL_PORTS),)
 SERIAL_PORTS		 = "\\\\.\\COM32,\\\\.\\COM31,\\\\.\\COM30,\\\\.\\COM29,\\\\.\\COM28,\\\\.\\COM27,\\\\.\\COM26,\\\\.\\COM25,\\\\.\\COM24,\\\\.\\COM23,\\\\.\\COM22,\\\\.\\COM21,\\\\.\\COM20,\\\\.\\COM19,\\\\.\\COM18,\\\\.\\COM17,\\\\.\\COM16,\\\\.\\COM15,\\\\.\\COM14,\\\\.\\COM13,\\\\.\\COM12,\\\\.\\COM11,\\\\.\\COM10,\\\\.\\COM9,\\\\.\\COM8,\\\\.\\COM7,\\\\.\\COM6,\\\\.\\COM5,\\\\.\\COM4,\\\\.\\COM3,\\\\.\\COM2,\\\\.\\COM1,\\\\.\\COM0"
 endif
 
-upload-usb:
+upload-usb: px4flow.px4
 	@echo Attempting to flash PX4FLOW board via USB
-	@python -u Tools/px_mkfw.py --board_id 6 > px4flow_prototype.px4
-	@python -u Tools/px_mkfw.py --prototype px4flow_prototype.px4 --image $(BINARY_BIN) > px4flow.px4
 	@python -u Tools/px_uploader.py px4flow.px4 --baud 921600 --port $(SERIAL_PORTS)
 
-
+.PHONY: all clean objcopy upload-jtag flash flash-bootloader flash-both flash-both-no-shutdown upload-usb
 #-include $(DEPS)

--- a/inc/usb_conf.h
+++ b/inc/usb_conf.h
@@ -108,7 +108,7 @@
   #define __packed    __packed
 #elif defined (__ICCARM__)     /* IAR Compiler */
   #define __packed    __packed
-#elif defined   ( __GNUC__ )   /* GNU Compiler */                        
+#elif defined   ( __GNUC__ )  && !defined(__packed) /* GNU Compiler */                        
   #define __packed    __attribute__ ((__packed__))
 #elif defined   (__TASKING__)  /* TASKING Compiler */
   #define __packed    __unaligned

--- a/lib/STM32_USB_OTG_Driver/src/usb_core.c
+++ b/lib/STM32_USB_OTG_Driver/src/usb_core.c
@@ -1955,13 +1955,13 @@ void USB_OTG_ActiveRemoteWakeup(USB_OTG_CORE_HANDLE *pdev)
   
   if (pdev->dev.DevRemoteWakeup) 
   {
-    dsts.d32 = USB_OTG_READ_REG32(&pdev->regs.DREGS->DSTS);
+    dsts.d32 = USB_OTG_READ_REG32(pdev->regs.DREGS->DSTS);
     if(dsts.b.suspsts == 1)
     {
       if(pdev->cfg.low_power)
       {
         /* un-gate USB Core clock */
-        power.d32 = USB_OTG_READ_REG32(&pdev->regs.PCGCCTL);
+        power.d32 = USB_OTG_READ_REG32(pdev->regs.PCGCCTL);
         power.b.gatehclk = 0;
         power.b.stoppclk = 0;
         USB_OTG_WRITE_REG32(pdev->regs.PCGCCTL, power.d32);
@@ -1969,9 +1969,9 @@ void USB_OTG_ActiveRemoteWakeup(USB_OTG_CORE_HANDLE *pdev)
       /* active Remote wakeup signaling */
       dctl.d32 = 0;
       dctl.b.rmtwkupsig = 1;
-      USB_OTG_MODIFY_REG32(&pdev->regs.DREGS->DCTL, 0, dctl.d32);
+      USB_OTG_MODIFY_REG32(pdev->regs.DREGS->DCTL, 0, dctl.d32);
       USB_OTG_BSP_mDelay(5);
-      USB_OTG_MODIFY_REG32(&pdev->regs.DREGS->DCTL, dctl.d32, 0 );
+      USB_OTG_MODIFY_REG32(pdev->regs.DREGS->DCTL, dctl.d32, 0 );
     }
   }
 }
@@ -1990,12 +1990,12 @@ void USB_OTG_UngateClock(USB_OTG_CORE_HANDLE *pdev)
     USB_OTG_DSTS_TypeDef     dsts;
     USB_OTG_PCGCCTL_TypeDef  power; 
     
-    dsts.d32 = USB_OTG_READ_REG32(&pdev->regs.DREGS->DSTS);
+    dsts.d32 = USB_OTG_READ_REG32(pdev->regs.DREGS->DSTS);
     
     if(dsts.b.suspsts == 1)
     {
       /* un-gate USB Core clock */
-      power.d32 = USB_OTG_READ_REG32(&pdev->regs.PCGCCTL);
+      power.d32 = USB_OTG_READ_REG32(pdev->regs.PCGCCTL);
       power.b.gatehclk = 0;
       power.b.stoppclk = 0;
       USB_OTG_WRITE_REG32(pdev->regs.PCGCCTL, power.d32);

--- a/lib/STM32_USB_OTG_Driver/src/usb_dcd_int.c
+++ b/lib/STM32_USB_OTG_Driver/src/usb_dcd_int.c
@@ -352,7 +352,7 @@ static uint32_t DCD_HandleResume_ISR(USB_OTG_CORE_HANDLE *pdev)
   if(pdev->cfg.low_power)
   {
     /* un-gate USB Core clock */
-    power.d32 = USB_OTG_READ_REG32(&pdev->regs.PCGCCTL);
+    power.d32 = USB_OTG_READ_REG32(pdev->regs.PCGCCTL);
     power.b.gatehclk = 0;
     power.b.stoppclk = 0;
     USB_OTG_WRITE_REG32(pdev->regs.PCGCCTL, power.d32);

--- a/src/main.c
+++ b/src/main.c
@@ -76,8 +76,8 @@ void buffer_reset(void);
 __ALIGN_BEGIN USB_OTG_CORE_HANDLE  USB_OTG_dev __ALIGN_END;
 
 /* fast image buffers for calculations */
-uint8_t* image_buffer_8bit_1 = ((uint8_t*) 0x10000000);
-uint8_t* image_buffer_8bit_2 = ((uint8_t*) ( 0x10000000 | FULL_IMAGE_SIZE ));
+uint8_t image_buffer_8bit_1[FULL_IMAGE_SIZE] __attribute__((section(".ccm")));
+uint8_t image_buffer_8bit_2[FULL_IMAGE_SIZE] __attribute__((section(".ccm")));
 uint8_t buffer_reset_needed;
 
 /* boot time in milliseconds ticks */

--- a/stm32f4.ld
+++ b/stm32f4.ld
@@ -93,7 +93,7 @@ SECTIONS
 
   /* Uninitialized data section */
   . = ALIGN(4);
-  .bss :
+  .bss (NOLOAD):
   {
     /* This is used by the startup in order to initialize the .bss secion */
     _sbss = .;         /* define a global symbol at bss start */
@@ -117,4 +117,10 @@ SECTIONS
     . = . + _Min_Stack_Size;
     . = ALIGN(4);
   } >RAM
+
+  .ccm (NOLOAD):
+  {
+      *(.ccm)
+      *(.ccm*)
+  } >CCM
 }


### PR DESCRIPTION
Some small changes: makefile dependencies work a bit better, -Werror is turned on.

The big change here is that the image_buffer_8bit buffers which live in CCM are placed there by the linker instead of being hardcoded to specific addresses.  This is less error-prone.