### PR TITLE
Don't assume the bootloader has left interrupts enabled

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -228,6 +228,8 @@ void buffer_reset(void) {
   */
 int main(void)
 {
+	__enable_irq();
+
 	/* load settings and parameters */
 	global_data_reset_param_defaults();
 	global_data_reset();


### PR DESCRIPTION
PX4/Bootloader leaves the interrupt-enable bit set when it transfers
control to the application, and this application didn't enable
interrupts itself.