### PR TITLE
Add an amplitude limiting filter for the variable qual

### DIFF
--- a/src/modules/flow/flow.c
+++ b/src/modules/flow/flow.c
@@ -404,6 +404,8 @@ uint8_t compute_flow(uint8_t *image1, uint8_t *image2, float x_rate, float y_rat
 	const uint16_t hist_size = 2*(winmax-winmin+1)+1;
 
 	/* variables */
+        uint8_t qualValue=255;
+        uint8_t qualThreshold=15;
         uint16_t pixLo = SEARCH_SIZE + 1;
         uint16_t pixHi = FRAME_SIZE - (SEARCH_SIZE + 1) - TILE_SIZE;
         uint16_t pixStep = (pixHi - pixLo) / NUM_BLOCKS + 1;
@@ -744,6 +746,8 @@ uint8_t compute_flow(uint8_t *image1, uint8_t *image2, float x_rate, float y_rat
 
 	/* calc quality */
 	uint8_t qual = (uint8_t)(meancount * 255 / (NUM_BLOCKS*NUM_BLOCKS));
-
+    if (qual-qualValue > qualThreshold || qualValue-qual > qualThreshold){
+        qualValue=qual;
+    }
 	return qual;
 }


### PR DESCRIPTION
Hello
When i do some experiments recently i notice that though the quality of picture is high,the variable qual still jitters.In order to avoid the jitter,i add an amplitude limiting filter.And after that the analyse look like smooth when it is stable.
First picture before change:
![before1](https://cloud.githubusercontent.com/assets/17217344/15102902/aa0cf04c-15d7-11e6-95da-3fa8271b7618.png)
Second picture before change:
![before2](https://cloud.githubusercontent.com/assets/17217344/15102916/d0fea06a-15d7-11e6-8f50-76ec5cde9473.png)
First picture After change:
![after1](https://cloud.githubusercontent.com/assets/17217344/15105082/29e9a030-15f1-11e6-97d8-62ed2d109cb9.png)
Second picture After change:
![after2](https://cloud.githubusercontent.com/assets/17217344/15105083/2c40a612-15f1-11e6-8a67-971e2a593411.png)



