### PR TITLE
Fix gyro compensation. Enable gyro compensation by default.

### DIFF
--- a/src/modules/flow/flow.c
+++ b/src/modules/flow/flow.c
@@ -678,7 +678,7 @@ uint8_t compute_flow(uint8_t *image1, uint8_t *image2, float x_rate, float y_rat
 				{
 					/* calc pixel of gyro */
 					float y_rate_pixel = y_rate * (get_time_between_images() / 1000000.0f) * focal_length_px;
-					float comp_x = histflowx + y_rate_pixel;
+					float comp_x = histflowx - y_rate_pixel;
 
                     /* clamp value to maximum search window size plus half pixel from subpixel search */
                     if (comp_x < (-SEARCH_SIZE - 0.5f))
@@ -697,7 +697,7 @@ uint8_t compute_flow(uint8_t *image1, uint8_t *image2, float x_rate, float y_rat
 				{
 					/* calc pixel of gyro */
 					float x_rate_pixel = x_rate * (get_time_between_images() / 1000000.0f) * focal_length_px;
-					float comp_y = histflowy - x_rate_pixel;
+					float comp_y = histflowy + x_rate_pixel;
 
 					/* clamp value to maximum search window size plus/minus half pixel from subpixel search */
 					if (comp_y < (-SEARCH_SIZE - 0.5f))

--- a/src/modules/flow/settings.c
+++ b/src/modules/flow/settings.c
@@ -182,8 +182,8 @@ void global_data_reset_param_defaults(void){
 	strcpy(global_data.param_name[PARAM_BOTTOM_FLOW_HIST_FILTER], "BFLOW_HIST_FIL");
 	global_data.param_access[PARAM_BOTTOM_FLOW_HIST_FILTER] = READ_WRITE;
 
-//	global_data.param[PARAM_BOTTOM_FLOW_GYRO_COMPENSATION] = 0;
-	global_data.param[PARAM_BOTTOM_FLOW_GYRO_COMPENSATION] = 0;
+	/* global_data.param[PARAM_BOTTOM_FLOW_GYRO_COMPENSATION] = 0; */
+	global_data.param[PARAM_BOTTOM_FLOW_GYRO_COMPENSATION] = 1;
 	strcpy(global_data.param_name[PARAM_BOTTOM_FLOW_GYRO_COMPENSATION], "BFLOW_GYRO_COM");
 	global_data.param_access[PARAM_BOTTOM_FLOW_GYRO_COMPENSATION] = READ_WRITE;
 


### PR DESCRIPTION
Plots:
* with `BFLOW_GYRO_COM = 0` (without compensation):
![without_comp_x_axis](https://user-images.githubusercontent.com/7851779/55157477-84095500-516d-11e9-86ac-fdd77a53fee7.png)
![without_comp_y_axis](https://user-images.githubusercontent.com/7851779/55157482-879cdc00-516d-11e9-93ff-e11242fa6022.png)
* with `BFLOW_GYRO_COM = 1`, but **before** fixes:
![with_comp_before_fixes_x_axis](https://user-images.githubusercontent.com/7851779/55157529-b024d600-516d-11e9-840c-8047cf7df973.png)
![with_comp_before_fixes_y_axis](https://user-images.githubusercontent.com/7851779/55157534-b3b85d00-516d-11e9-939e-447831544ed7.png)
* with `BFLOW_GYRO_COM = 1`, but **after** fixes: 
![with_comp_after_fixes_x_axis](https://user-images.githubusercontent.com/7851779/55157571-c7fc5a00-516d-11e9-8523-25e819385f02.png)
![with_comp_after_fixes_y_axis](https://user-images.githubusercontent.com/7851779/55157575-caf74a80-516d-11e9-8110-174b3ea6901a.png)

So, before my fixes it looks like the signs was messed. Plot of gyro is opposite to plot of optical flow estimation. Also, with enabled compensation before fixes, px4 ekf_estimator reject estimation of optical_flow on every rotation of copter.

After fixes the flight with enabled optical flow became more stable and it's possible to see, that plots became more smooth, even in comparison with enabled gyro compensation.

I also enable compensation in settings. It was suspiciously changed to **0** in [commit, that doesn't related to gyro compensation at all](https://github.com/PX4/Flow/commit/6d584340e5691e81146fbd3fce17881380fec8ba#diff-cfb42647f460cb87f3decb6b388a5cb1R179).

My environment:
* PX4 Firmware 1.8.2
* Pixhawk 1.8
* PX4Flow with firmware, compiled from current master.

Hope this changes'll help and can make px4flow great again!
Thanks.
